### PR TITLE
Add input file switch to base64 command

### DIFF
--- a/helper_scripts/createpayload.sh
+++ b/helper_scripts/createpayload.sh
@@ -7,7 +7,7 @@ serial=$(cat state.tfstate | jq '.serial')
 md5_compute=$(md5 -q state.tfstate)
 md5=\"$md5_compute\"
 lineage=$(cat state.tfstate | jq '.lineage')
-base64_encode=$(base64 state.tfstate)
+base64_encode=$(base64 -i state.tfstate)
 state=\"$base64_encode\"
 
 


### PR DESCRIPTION
I noticed this flag was needed while going through the learn tutorial

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204157375032549